### PR TITLE
refactor(permissions): replace location permissions with nearby devic…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,10 +22,10 @@
         <config-file target="AndroidManifest.xml" parent="/manifest">
             <uses-permission android:name="android.permission.BLUETOOTH" />
             <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-            <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-            <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+            <!-- Removed location permissions -->
             <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
             <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+            <uses-permission android:name="android.permission.NEARBY_DEVICES" />
         </config-file>
         
         <framework src="org.altbeacon:android-beacon-library:2.19.5" />
@@ -44,17 +44,7 @@
             <string>This app needs Bluetooth access to detect beacons.</string>
         </config-file>
         
-        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-            <string>This app needs location access to detect beacons.</string>
-        </config-file>
-        
-        <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
-            <string>This app needs location access to detect beacons.</string>
-        </config-file>
-        
-        <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
-            <string>This app needs location access to detect beacons.</string>
-        </config-file>
+        <!-- Remove location usage descriptions -->
         
         <source-file src="src/ios/BeaconDetectorPlugin.swift" />
         <dependency id="cordova-plugin-add-swift-support" version="2.0.2" />

--- a/src/ios/BeaconDetectorPlugin.swift
+++ b/src/ios/BeaconDetectorPlugin.swift
@@ -48,8 +48,8 @@ class BeaconDetectorPlugin: CDVPlugin, CLLocationManagerDelegate {
         }
         
         self.commandDelegate.run {
-            // Request authorization
-            self.requestLocationAuthorization()
+            // Request authorization for Bluetooth usage instead of location
+            self.requestBluetoothAuthorization()
             
             // Create regions for each unique UUID in the beacon data
             var uniqueUUIDs: Set<String> = []
@@ -203,15 +203,21 @@ class BeaconDetectorPlugin: CDVPlugin, CLLocationManagerDelegate {
     
     // MARK: - Helper Methods
     
-    private func requestLocationAuthorization() {
-        let status = CLLocationManager.authorizationStatus()
+    private func requestBluetoothAuthorization() {
+        // In iOS, we don't need to explicitly request Bluetooth authorization
+        // The NSBluetoothAlwaysUsageDescription in Info.plist will trigger the system prompt
+        // when Bluetooth is accessed
         
-        if status == .notDetermined {
-            locationManager.requestAlwaysAuthorization()
-        } else if status == .denied || status == .restricted {
-            print("Location services are disabled for this app")
+        // For iOS 13+, we can check Bluetooth authorization status
+        if #available(iOS 13.0, *) {
+            let cbManager = CBCentralManager()
+            let cbState = cbManager.state
+            print("Bluetooth authorization status: \(cbState.rawValue)")
         }
     }
+    
+    // Remove the location authorization request method
+    // private func requestLocationAuthorization() { ... }
     
     private func calculateDistance(rssi: Int, txPower: Int) -> Double {
         if rssi == 0 {


### PR DESCRIPTION
…es and Bluetooth

The commit removes location-related permissions and usage descriptions, replacing them with Bluetooth and nearby devices permissions. This change aligns with the updated requirements for beacon detection, which no longer relies on location services but instead focuses on Bluetooth and nearby device access. The modifications span across Android and iOS configurations and code, ensuring compatibility and adherence to the new permission model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated permission handling to use Bluetooth and nearby device permissions instead of location permissions for beacon scanning on both Android and iOS.
- **Chores**
	- Removed all location-related permissions and descriptions from app configuration files. 
	- Adjusted permission prompts to align with the latest platform requirements for Android and iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->